### PR TITLE
Align Dremio support matrix with versioned-reference coverage

### DIFF
--- a/docs/dremio-support-matrix.md
+++ b/docs/dremio-support-matrix.md
@@ -41,9 +41,9 @@ Reference export timestamp: 2026-02-28T14:20:54.462923+00:00
 | 12 | CREATE FOLDER | NATIVE | `fixtures/dremio/reference-commands/12_create_folder.sql` | `CreateFolder` command path |
 | 13 | CREATE PIPE Enterprise | NATIVE | `fixtures/dremio/reference-commands/13_create_pipe.sql` | `Pipe` command path |
 | 14 | CREATE TABLE | AST | `fixtures/dremio/reference-commands/14_create_table.sql` | SQL AST path |
-| 15 | CREATE TABLE AS | AST | `fixtures/dremio/reference-commands/15_create_table_as.sql` | SQL AST path |
+| 15 | CREATE TABLE AS | AST | `fixtures/dremio/reference-commands/15_create_table_as.sql` | SQL AST path + versioned source ref variant |
 | 16 | CREATE TAG | NATIVE | `fixtures/dremio/reference-commands/16_create_tag.sql` | `BranchTag` command path |
-| 17 | CREATE VIEW | AST | `fixtures/dremio/reference-commands/17_create_view.sql` | SQL AST path |
+| 17 | CREATE VIEW | AST | `fixtures/dremio/reference-commands/17_create_view.sql` | SQL AST path + versioned source ref variant |
 | 18 | DELETE | AST | `fixtures/dremio/reference-commands/18_delete.sql` | SQL AST path |
 | 19 | DESCRIBE PIPE Enterprise | NATIVE | `fixtures/dremio/reference-commands/19_describe_pipe.sql` | `Pipe` command path |
 | 20 | DROP | AST | `fixtures/dremio/reference-commands/20_drop.sql` | SQL AST path |
@@ -52,7 +52,7 @@ Reference export timestamp: 2026-02-28T14:20:54.462923+00:00
 | 23 | DROP TAG | NATIVE | `fixtures/dremio/reference-commands/23_drop_tag.sql` | `BranchTag` command path |
 | 24 | DROP VIEW | AST | `fixtures/dremio/reference-commands/24_drop_view.sql` | SQL AST path |
 | 25 | GRANT/REVOKE Enterprise | NATIVE | `fixtures/dremio/reference-commands/25_grant_revoke.sql` | Generic Dremio command path |
-| 26 | INSERT | AST | `fixtures/dremio/reference-commands/26_insert.sql` | SQL AST + insert formatting path |
+| 26 | INSERT | AST | `fixtures/dremio/reference-commands/26_insert.sql` | SQL AST + insert formatting path + versioned source ref variant |
 | 27 | MERGE | AST | `fixtures/dremio/reference-commands/27_merge.sql` | SQL AST path |
 | 28 | MERGE BRANCH | NATIVE | `fixtures/dremio/reference-commands/28_merge_branch.sql` | `BranchTag` command path |
 | 29 | OPTIMIZE TABLE | NATIVE | `fixtures/dremio/reference-commands/29_optimize_table.sql` | `TableMaintenance` command path |
@@ -96,8 +96,10 @@ Reference export timestamp: 2026-02-28T14:20:54.462923+00:00
 ## Evaluation Notes
 
 - Canonical command corpus: `fixtures/dremio/reference-commands/` with 57 fixture files.
+- Versioned source refs are covered in canonical `CREATE TABLE AS`, `CREATE VIEW`, and `INSERT` fixtures.
 - Parser guard: strict-mode test covers all 57 fixture files.
 - Formatter guard: idempotence + keyword-case matrix (upper/lower) covers all 57 fixture files.
+- Statement-level semantic-preservation tests assert version-clause retention for CTAS/CREATE VIEW/INSERT in parser + formatter paths.
 - `sqlparser` has been upgraded to `0.61.0` and all parser/formatter tests pass with the upgraded AST APIs.
 
 ## Backlog (Priority Order)

--- a/docs/dremio.md
+++ b/docs/dremio.md
@@ -17,6 +17,7 @@ Use `--dialect dremio` for Dremio SQL inputs and fixtures under `fixtures/dremio
 
 - Dremio-specific recognized keywords are case-formatted according to `keyword_case`
 - Version clauses are formatted as separate lines after the base `FROM` relation when present
+- Version clauses are preserved in top-level `SELECT` and in `SELECT` bodies for `CREATE TABLE AS`, `CREATE VIEW ... AS`, and `INSERT ... SELECT`
 - Quoted path segments are preserved (for example, source names with dots or dashes)
 - `TABLE(EXTERNAL_QUERY(...))` and similar table functions use nested formatting so inner queries remain readable
 

--- a/fixtures/dremio/reference-commands/15_create_table_as.sql
+++ b/fixtures/dremio/reference-commands/15_create_table_as.sql
@@ -1,2 +1,3 @@
 CREATE TABLE my_space.ctas_table AS SELECT * FROM my_space.my_table;
 CREATE TABLE my_space.ctas_partitioned PARTITION BY (MONTH(created_at)) AS SELECT id, created_at FROM my_space.my_table;
+CREATE TABLE my_space.ctas_from_tag AS SELECT * FROM my_space.my_table AT TAG release_candidate;

--- a/fixtures/dremio/reference-commands/17_create_view.sql
+++ b/fixtures/dremio/reference-commands/17_create_view.sql
@@ -1,2 +1,3 @@
 CREATE OR REPLACE VIEW my_space.my_view AS SELECT id FROM my_space.my_table;
 CREATE VIEW my_space.my_view2 AS SELECT id, SUM(amount) AS total_amount FROM my_space.my_table GROUP BY id;
+CREATE VIEW my_space.my_view_from_branch AS SELECT id FROM my_space.my_table AT BRANCH release AS OF TIMESTAMP '2025-01-01 00:00:00';

--- a/fixtures/dremio/reference-commands/26_insert.sql
+++ b/fixtures/dremio/reference-commands/26_insert.sql
@@ -1,2 +1,3 @@
 INSERT INTO my_space.my_table (id, amount) VALUES (1, 10.5), (2, 20.0);
 INSERT INTO my_space.my_table SELECT id, amount FROM my_space.source_table;
+INSERT INTO my_space.my_table SELECT id, amount FROM my_space.source_table AT COMMIT 'a1b2c3d4';


### PR DESCRIPTION
## Summary
- add versioned-reference variants to canonical Dremio reference fixtures for CREATE TABLE AS, CREATE VIEW, and INSERT
- update Dremio support matrix notes for rows 15/17/26 to call out versioned-source coverage
- clarify Dremio docs that version clauses are preserved in SELECT, CTAS, CREATE VIEW AS, and INSERT SELECT

## Testing
- cargo test dremio_reference_command_fixtures -- --nocapture
- cargo test version_clause -- --nocapture
- cargo test

Closes #4