### PR TITLE
Add dbt templating support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ cat query.sql | sqlchisel --stdin --format
 - Formatting heuristics (non-contract): [`docs/style-guide.md`](docs/style-guide.md)
 - Dremio support notes: [`docs/dremio.md`](docs/dremio.md)
 - Dremio reference coverage tracker: [`docs/dremio-support-matrix.md`](docs/dremio-support-matrix.md)
+- dbt/Jinja support tracker: [`docs/dbt-support-plan.md`](docs/dbt-support-plan.md)
 - Editor integrations: [`docs/editor-integrations.md`](docs/editor-integrations.md)
 
 ## Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory separates stable behavior from formatting heuristics and integrat
 - [`style-guide.md`](style-guide.md): current formatting heuristics and examples (non-contract)
 - [`dremio.md`](dremio.md): Dremio-specific supported syntax and formatting expectations
 - [`dremio-support-matrix.md`](dremio-support-matrix.md): command-by-command Dremio SQL reference coverage tracker
+- [`dbt-support-plan.md`](dbt-support-plan.md): dbt/Jinja templating support tracker
 
 ## Integrations and Development
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -26,6 +26,7 @@ Constraints:
 ## Common Flags
 
 - `--dialect <ansi|dremio>`
+- `--templating <passthrough|dbt>`
 - `--keyword-case <upper|lower|capitalize>`
 - `--line-length <N>`
 - `--indent-width <N>`
@@ -40,6 +41,8 @@ Constraints:
 When a provided path is a directory, `sqlchisel` recursively collects matching files.
 
 - Default include glob: `**/*.sql`
+- In `--templating dbt`, default include globs are `**/*.sql`, `**/*.sql.j2`,
+  `**/*.sql.jinja`, and `**/*.sql.jinja2`
 - `--include` overrides the default include list
 - `--exclude` filters paths out
 - Ignored directories during recursion: `.git`, `target`, `.cargo`

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,6 +23,7 @@ line_length = 100
 indent_width = 2
 keyword_case = "upper"
 dialect = "ansi"
+templating = "passthrough"
 select_list_style = "auto"
 strict = false
 ```
@@ -33,6 +34,7 @@ strict = false
 - `indent_width` (`usize`): spaces per indent level. Default: `2`.
 - `keyword_case` (`"upper" | "lower" | "capitalize"`): keyword rendering. Default: `"upper"`.
 - `dialect` (`"ansi" | "dremio"`): parser/formatter dialect. Default: `"ansi"`.
+- `templating` (`"passthrough" | "dbt"`): template handling. Default: `"passthrough"`.
 - `select_list_style` (`"auto" | "per_line"`): select-list layout strategy. Default: `"auto"`.
 - `strict` (`bool`): fail on parse errors instead of raw fallback. Default: `false`.
 
@@ -44,5 +46,6 @@ These flags override config values for the current run:
 - `--indent-width`
 - `--keyword-case`
 - `--dialect`
+- `--templating`
 - `--select-list-style`
 - `--strict` (enables strict mode)

--- a/docs/dbt-support-plan.md
+++ b/docs/dbt-support-plan.md
@@ -1,0 +1,96 @@
+# dbt Syntax Support Plan
+
+Track dbt templating support here so parser, formatter, fixtures, and docs progress stays visible in-repo.
+
+## References
+
+- dbt SQL models: <https://docs.getdbt.com/docs/build/sql-models>
+- dbt Jinja and macros: <https://docs.getdbt.com/docs/build/jinja-macros>
+- dbt Jinja functions: <https://docs.getdbt.com/reference/dbt-jinja-functions>
+- dbt data tests: <https://docs.getdbt.com/docs/build/data-tests>
+- Jinja template syntax: <https://jinja.palletsprojects.com/en/stable/templates/>
+- Dremio dbt guide: <https://docs.dremio.com/current/data-products/deploy-with-dbt/>
+- dbt-dremio walkthrough: <https://github.com/dremio/dbt-dremio/blob/main/docs/walkthrough.md>
+
+## Status Legend
+
+- `PASSTHROUGH`: Intentionally returned unchanged.
+- `PLACEHOLDER`: Jinja/dbt syntax is protected and restored exactly while surrounding SQL can format.
+- `FORMATTED`: SQL inside the syntax family is formatted where safe.
+- `PARTIAL`: Some representative forms work, but known syntax remains.
+- `BLOCKED`: Not supported by the current formatter architecture.
+
+## Milestone 1: Tracker and Public Interface
+
+- [x] Add this tracker file.
+- [x] Link this tracker from `docs/README.md`.
+- [x] Add `templating = "passthrough" | "dbt"` config support.
+- [x] Add `--templating <passthrough|dbt>` CLI support.
+- [x] Keep `templating = "passthrough"` as the default.
+- [x] Include dbt SQL template extensions during directory traversal in dbt mode.
+- [x] Document canonical Dremio invocation:
+  `sqlchisel --dialect dremio --templating dbt --format models/my_model.sql`.
+
+## Milestone 2: dbt/Jinja Scanner Foundation
+
+- [x] Preserve exact contents of `{{ ... }}`, `{% ... %}`, and `{# ... #}`.
+- [x] Preserve whitespace-trim forms such as `{{- ... -}}` and `{%- ... -%}`.
+- [x] Support quoted strings inside template tags.
+- [x] Treat `{% raw %}...{% endraw %}` as an opaque preserved block.
+- [x] Protect Jinja markers inside SQL comments and string literals.
+- [x] Avoid splitting SQL statements on semicolons inside dbt/Jinja tags.
+- [ ] Add strict-mode diagnostics for malformed template delimiters.
+
+## Milestone 3: Core dbt Model Syntax
+
+- [x] Format model SQL around standalone `{{ config(...) }}` blocks.
+- [x] Preserve relation-like placeholders: `ref`, versioned/two-argument `ref`, `source`, and `this`.
+- [x] Preserve expression placeholders: `var`, `env_var`, `target`, `is_incremental`, `adapter`, `dispatch`, and custom macro calls.
+- [x] Preserve dbt dependency comments such as `-- depends_on: {{ ref(...) }}`.
+- [ ] Add broader package macro fixtures for common packages such as `dbt_utils`.
+
+## Milestone 4: Control Flow and Generated SQL
+
+- [x] Preserve standalone `{% if %}`, `{% elif %}`, `{% else %}`, `{% endif %}` lines.
+- [x] Preserve standalone `{% for %}` and `{% endfor %}` lines.
+- [x] Preserve standalone `{% set %}`, `{% endset %}`, `{% do %}`, `{% call %}`, and `{% endcall %}` lines.
+- [x] Format SQL inside branch bodies when the protected SQL remains parseable.
+- [ ] Add targeted handling for generated select-list comma patterns that are not parseable after placeholder preservation.
+
+## Milestone 5: dbt Resource Coverage
+
+- [x] Add dbt model fixtures.
+- [x] Add Dremio dbt fixtures.
+- [x] Add reference syntax fixtures for tests, snapshots, macros, materializations, statement blocks, hooks, operations, and package macros.
+- [ ] Expand each reference syntax fixture from representative syntax to broader dbt docs coverage.
+- [ ] Add optional manual smoke project for `dbt parse`/`dbt compile`.
+
+## Milestone 6: Dremio + dbt Coverage
+
+- [x] Add Dremio dbt fixtures for `object_storage_source`, `object_storage_path`, `dremio_space`, and `dremio_space_folder`.
+- [x] Add Dremio incremental fixture with `is_incremental()` and `{{ this }}`.
+- [x] Cover Dremio SQL mixed with dbt placeholders and versioned refs.
+- [x] Cross-link this tracker with `docs/dremio-support-matrix.md`.
+- [ ] Expand adapter-style DDL/DML fixtures as dbt-dremio coverage grows.
+
+## Syntax Coverage Matrix
+
+| Syntax Family | Status | Fixture Area | Notes |
+| --- | --- | --- | --- |
+| `{{ config(...) }}` | `PLACEHOLDER` | `fixtures/dbt/ansi`, `fixtures/dbt/dremio` | Standalone config blocks are restored exactly. |
+| `ref`, versioned `ref`, `source`, `this` | `PLACEHOLDER` | `fixtures/dbt/ansi`, `fixtures/dbt/dremio` | Relation placeholders format as SQL-safe identifiers internally. |
+| `var`, `env_var`, `target`, custom macros | `PLACEHOLDER` | `fixtures/dbt/ansi` | Expression placeholders are restored exactly. |
+| `is_incremental()` branches | `FORMATTED` | `fixtures/dbt/dremio` | Branch SQL formats when the protected SQL remains parseable. |
+| `{% if %}` / `{% for %}` control flow | `PARTIAL` | `fixtures/dbt/reference-syntax` | Standalone blocks are preserved; complex generated SQL may raw-fallback. |
+| `{% macro %}` / `{% materialization %}` | `PARTIAL` | `fixtures/dbt/reference-syntax` | SQL inside parseable bodies formats; non-SQL Jinja stays opaque. |
+| `{% test %}` / snapshots | `PARTIAL` | `fixtures/dbt/reference-syntax` | Representative SQL-bearing forms covered. |
+| statement blocks / `run_query` | `PARTIAL` | `fixtures/dbt/reference-syntax` | Preserved and restored; SQL strings are not independently formatted. |
+| dbt YAML SQL strings | `BLOCKED` | none | Out of scope for this SQL formatter. |
+
+## Acceptance Criteria
+
+- [x] `cargo fmt --check`
+- [x] `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] `cargo test`
+- [x] Every dbt fixture formats idempotently.
+- [x] Default Jinja passthrough behavior remains unchanged without `--templating dbt`.

--- a/docs/dremio-support-matrix.md
+++ b/docs/dremio-support-matrix.md
@@ -22,6 +22,7 @@ Reference export timestamp: 2026-02-28T14:20:54.462923+00:00
 - SQL statement formatter dispatch: [`src/format/sql/mod.rs`](../src/format/sql/mod.rs) (`format_statement`)
 - Dremio command formatter: [`src/format/sql/dremio.rs`](../src/format/sql/dremio.rs)
 - Regression fixtures: `fixtures/dremio/{in,expected,out}`
+- dbt/Jinja templating on Dremio: [`docs/dbt-support-plan.md`](dbt-support-plan.md)
 
 ## Coverage Matrix (57 Dremio Command Pages)
 

--- a/docs/format-contract.md
+++ b/docs/format-contract.md
@@ -56,8 +56,9 @@ Strict behavior (`strict = true` or `--strict`):
 
 ## Jinja Passthrough
 
-- If the input contains Jinja markers (`{{`, `{%`, or `{#`), `sqlchisel` currently returns the input unchanged.
+- By default, if the input contains Jinja markers (`{{`, `{%`, or `{#`), `sqlchisel` returns the input unchanged.
 - This passthrough behavior is part of the current stable contract to avoid corrupting templated SQL.
+- When `templating = "dbt"` or `--templating dbt` is enabled, dbt/Jinja tags are protected and restored while surrounding SQL is formatted.
 
 ## CLI Mode Contract
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -109,6 +109,12 @@ SELECT * FROM other;
 - Preserve string literal casing and contents
 - Preserve inline and block comments relative to nearby SQL where possible
 
+## dbt/Jinja Templates
+
+- Default templated SQL behavior is passthrough.
+- With `--templating dbt`, dbt/Jinja tags are preserved exactly while surrounding SQL is formatted where safe.
+- dbt templating support progress is tracked in [`dbt-support-plan.md`](dbt-support-plan.md).
+
 ## Future Tuning Areas
 
 - Numeric thresholds for select-list layout tiers

--- a/fixtures/dbt/ansi/expected/01_model.sql
+++ b/fixtures/dbt/ansi/expected/01_model.sql
@@ -1,0 +1,4 @@
+{{ config(materialized="table") }}
+SELECT id, {{ var("country_expression", "country") }} AS country, amount FROM {{ ref("orders") }}
+WHERE created_at >= {{ var("start_date") }}
+-- depends_on: {{ ref("dim_dates") }}

--- a/fixtures/dbt/ansi/in/01_model.sql
+++ b/fixtures/dbt/ansi/in/01_model.sql
@@ -1,0 +1,4 @@
+{{ config(materialized="table") }}
+
+select id, {{ var("country_expression", "country") }} as country, amount from {{ ref("orders") }} where created_at >= {{ var("start_date") }}
+-- depends_on: {{ ref("dim_dates") }}

--- a/fixtures/dbt/ansi/out/01_model.sql
+++ b/fixtures/dbt/ansi/out/01_model.sql
@@ -1,0 +1,4 @@
+{{ config(materialized="table") }}
+SELECT id, {{ var("country_expression", "country") }} AS country, amount FROM {{ ref("orders") }}
+WHERE created_at >= {{ var("start_date") }}
+-- depends_on: {{ ref("dim_dates") }}

--- a/fixtures/dbt/dremio/expected/01_incremental.sql
+++ b/fixtures/dbt/dremio/expected/01_incremental.sql
@@ -1,0 +1,9 @@
+{{ config(materialized="incremental", object_storage_source="lake", object_storage_path="/dbt", dremio_space="analytics", dremio_space_folder="marts") }}
+SELECT *
+FROM {{ source("raw", "orders") }}
+AT BRANCH {{ var("nessie_branch") }}
+{% if is_incremental() %}
+WHERE updated_at > (
+    SELECT MAX(updated_at) FROM {{ this }}
+  )
+{% endif %}

--- a/fixtures/dbt/dremio/in/01_incremental.sql
+++ b/fixtures/dbt/dremio/in/01_incremental.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="incremental", object_storage_source="lake", object_storage_path="/dbt", dremio_space="analytics", dremio_space_folder="marts") }}
+
+select * from {{ source("raw", "orders") }} at branch {{ var("nessie_branch") }}
+{% if is_incremental() %}
+where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}

--- a/fixtures/dbt/dremio/out/01_incremental.sql
+++ b/fixtures/dbt/dremio/out/01_incremental.sql
@@ -1,0 +1,9 @@
+{{ config(materialized="incremental", object_storage_source="lake", object_storage_path="/dbt", dremio_space="analytics", dremio_space_folder="marts") }}
+SELECT *
+FROM {{ source("raw", "orders") }}
+AT BRANCH {{ var("nessie_branch") }}
+{% if is_incremental() %}
+WHERE updated_at > (
+    SELECT MAX(updated_at) FROM {{ this }}
+  )
+{% endif %}

--- a/fixtures/dbt/reference-syntax/01_resources.sql
+++ b/fixtures/dbt/reference-syntax/01_resources.sql
@@ -1,0 +1,12 @@
+{% snapshot orders_snapshot %}
+{{ config(target_schema="snapshots", unique_key="id", strategy="timestamp", updated_at="updated_at") }}
+select id, updated_at from {{ source("raw", "orders") }}
+{% endsnapshot %}
+
+{% test accepted_status(model, column_name) %}
+select * from {{ model }} where {{ column_name }} not in ("placed", "shipped")
+{% endtest %}
+
+{% macro cents_to_dollars(column_name, scale=2) %}
+({{ column_name }} / 100)::numeric(16, {{ scale }})
+{% endmacro %}

--- a/fixtures/dbt/reference-syntax/02_materialization.sql
+++ b/fixtures/dbt/reference-syntax/02_materialization.sql
@@ -1,0 +1,7 @@
+{% materialization table, adapter="dremio" %}
+{% set target_relation = this %}
+{% call statement("main") %}
+create table {{ target_relation }} as select * from {{ ref("orders") }}
+{% endcall %}
+{% do adapter.commit() %}
+{% endmaterialization %}

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,13 @@ pub enum DialectKind {
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TemplatingMode {
+    Passthrough,
+    Dbt,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SelectListStyle {
     Auto,
@@ -30,6 +37,7 @@ pub struct FormatterConfig {
     pub indent_width: usize,
     pub keyword_case: KeywordCase,
     pub dialect: DialectKind,
+    pub templating: TemplatingMode,
     pub select_list_style: SelectListStyle,
     pub strict: bool,
 }
@@ -41,6 +49,7 @@ impl Default for FormatterConfig {
             indent_width: 2,
             keyword_case: KeywordCase::Upper,
             dialect: DialectKind::Ansi,
+            templating: TemplatingMode::Passthrough,
             select_list_style: SelectListStyle::Auto,
             strict: false,
         }

--- a/src/format/sql/comments.rs
+++ b/src/format/sql/comments.rs
@@ -109,6 +109,9 @@ pub(super) fn reattach_comments(
 
                 while let Some(c) = comment_iter.peek() {
                     if !c.inline_with_prev && c.index == non_ws_idx {
+                        if !out.is_empty() && !out.ends_with('\n') {
+                            out.push('\n');
+                        }
                         if !indent.is_empty() {
                             out.push_str(&indent);
                         }
@@ -175,6 +178,9 @@ pub(super) fn reattach_comments(
                 out.push_str(spacer);
                 out.push_str(&c.content);
             } else {
+                if !out.is_empty() && !out.ends_with('\n') {
+                    out.push('\n');
+                }
                 if !indent.is_empty() {
                     out.push_str(&indent);
                 }

--- a/src/format/sql/jinja.rs
+++ b/src/format/sql/jinja.rs
@@ -1,14 +1,15 @@
 #[derive(Clone)]
 pub(super) struct JinjaFragment {
-    placeholder: String,
+    token: String,
     content: String,
-    kind: JinjaKind,
+    replacement: JinjaReplacement,
 }
 
 #[derive(Clone, Copy)]
-enum JinjaKind {
-    Expr,
-    Block,
+enum JinjaReplacement {
+    Inline,
+    StandaloneLine,
+    BlockComment,
 }
 
 pub(super) fn contains_jinja_markers(input: &str) -> bool {
@@ -21,116 +22,43 @@ pub(super) fn preserve_jinja_expressions(input: &str) -> (String, Vec<JinjaFragm
     let bytes = input.as_bytes();
     let mut idx = 0usize;
 
-    let mut in_single = false;
-    let mut in_double = false;
-    let mut in_line_comment = false;
-    let mut in_block_comment = 0usize;
-
     while idx < bytes.len() {
         let c = bytes[idx] as char;
 
-        if in_line_comment {
-            out.push(c);
-            if c == '\n' {
-                in_line_comment = false;
-            }
-            idx += 1;
-            continue;
-        }
-
-        if in_block_comment > 0 {
-            out.push(c);
-            if c == '/' && idx + 1 < bytes.len() && bytes[idx + 1] == b'*' {
-                in_block_comment += 1;
-            } else if c == '*' && idx + 1 < bytes.len() && bytes[idx + 1] == b'/' {
-                in_block_comment -= 1;
-            }
-            idx += 1;
-            continue;
-        }
-
-        if in_single {
-            out.push(c);
-            if c == '\'' {
-                in_single = false;
-            }
-            idx += 1;
-            continue;
-        }
-
-        if in_double {
-            out.push(c);
-            if c == '"' {
-                in_double = false;
-            }
-            idx += 1;
-            continue;
-        }
-
-        if c == '-' && idx + 1 < bytes.len() && bytes[idx + 1] == b'-' {
-            out.push_str("--");
-            idx += 2;
-            in_line_comment = true;
-            continue;
-        }
-        if c == '/' && idx + 1 < bytes.len() && bytes[idx + 1] == b'*' {
-            out.push_str("/*");
-            idx += 2;
-            in_block_comment = 1;
-            continue;
-        }
-
-        // Detect inline jinja expression {{ ... }} even if it spans multiple characters
         if idx + 1 < bytes.len() && bytes[idx] == b'{' && bytes[idx + 1] == b'{' {
             let start = idx;
-            idx += 2;
-            while idx + 1 < bytes.len() {
-                if bytes[idx] == b'}' && bytes[idx + 1] == b'}' {
-                    idx += 2;
-                    break;
-                }
-                idx += 1;
-            }
-            let raw = &input[start..idx];
-            let placeholder = format!("JINJA_EXPR_{}", frags.len());
-            frags.push(JinjaFragment {
-                placeholder: placeholder.clone(),
-                content: raw.to_string(),
-                kind: JinjaKind::Expr,
-            });
-            out.push_str(&placeholder);
+            let end = find_tag_end(input, idx + 2, b'}', b'}').unwrap_or(input.len());
+            push_fragment(input, start, end, &mut out, &mut frags, JinjaTagKind::Expr);
+            idx = end;
             continue;
         }
 
-        // Detect jinja block/comment tags and keep them as placeholders so we can reinsert later.
-        if idx + 1 < bytes.len()
-            && bytes[idx] == b'{'
-            && (bytes[idx + 1] == b'%' || bytes[idx + 1] == b'#')
-        {
+        if idx + 1 < bytes.len() && bytes[idx] == b'{' && bytes[idx + 1] == b'%' {
             let start = idx;
-            idx += 2;
-            while idx + 1 < bytes.len() {
-                if (bytes[idx] == b'%' || bytes[idx] == b'#') && bytes[idx + 1] == b'}' {
-                    idx += 2;
-                    break;
-                }
-                idx += 1;
-            }
-            let raw = &input[start..idx];
-            let placeholder = format!("JINJA_BLOCK_{}", frags.len());
-            frags.push(JinjaFragment {
-                placeholder: placeholder.clone(),
-                content: raw.to_string(),
-                kind: JinjaKind::Block,
-            });
-            out.push_str(&placeholder);
+            let first_end = find_tag_end(input, idx + 2, b'%', b'}').unwrap_or(input.len());
+            let end = if block_tag_name(&input[start..first_end]) == Some("raw") {
+                find_endraw_block(input, first_end).unwrap_or(input.len())
+            } else {
+                first_end
+            };
+            push_fragment(input, start, end, &mut out, &mut frags, JinjaTagKind::Block);
+            idx = end;
             continue;
         }
 
-        if c == '\'' {
-            in_single = true;
-        } else if c == '"' {
-            in_double = true;
+        if idx + 1 < bytes.len() && bytes[idx] == b'{' && bytes[idx + 1] == b'#' {
+            let start = idx;
+            let end = find_tag_end(input, idx + 2, b'#', b'}').unwrap_or(input.len());
+            push_fragment(
+                input,
+                start,
+                end,
+                &mut out,
+                &mut frags,
+                JinjaTagKind::Comment,
+            );
+            idx = end;
+            continue;
         }
 
         out.push(c);
@@ -142,21 +70,166 @@ pub(super) fn preserve_jinja_expressions(input: &str) -> (String, Vec<JinjaFragm
 
 pub(super) fn restore_jinja_expressions(mut output: String, frags: Vec<JinjaFragment>) -> String {
     for frag in frags {
-        match frag.kind {
-            JinjaKind::Expr => {
-                output = output.replace(&frag.placeholder, &frag.content);
+        match frag.replacement {
+            JinjaReplacement::Inline => {
+                output = output.replace(&frag.token, &frag.content);
             }
-            JinjaKind::Block => {
-                // Replace with optional leading whitespace trimmed so block tags return to column 0.
+            JinjaReplacement::StandaloneLine => {
                 let re = regex::Regex::new(&format!(
-                    "(?m)^\\s*{}\\s*$",
-                    regex::escape(&frag.placeholder)
+                    "(?m)^[ \\t]*--[ \\t]*{}[ \\t]*$",
+                    regex::escape(&frag.token)
                 ))
                 .expect("regex");
                 let replaced = re.replace_all(&output, frag.content.as_str()).into_owned();
-                output = replaced.replace(&frag.placeholder, &frag.content);
+                output = replaced.replace(&frag.token, &frag.content);
+            }
+            JinjaReplacement::BlockComment => {
+                let re = regex::Regex::new(&format!(
+                    r"/\*[ \t]*{}[ \t]*\*/",
+                    regex::escape(&frag.token)
+                ))
+                .expect("regex");
+                let replaced = re.replace_all(&output, frag.content.as_str()).into_owned();
+                output = replaced.replace(&frag.token, &frag.content);
             }
         }
     }
     output
+}
+
+#[derive(Clone, Copy)]
+enum JinjaTagKind {
+    Expr,
+    Block,
+    Comment,
+}
+
+fn push_fragment(
+    input: &str,
+    start: usize,
+    end: usize,
+    out: &mut String,
+    frags: &mut Vec<JinjaFragment>,
+    kind: JinjaTagKind,
+) {
+    let content = &input[start..end];
+    let token = match kind {
+        JinjaTagKind::Expr => format!("SQLCHISEL_JINJA_EXPR_{}__", frags.len()),
+        JinjaTagKind::Block => format!("SQLCHISEL_JINJA_BLOCK_{}__", frags.len()),
+        JinjaTagKind::Comment => format!("SQLCHISEL_JINJA_COMMENT_{}__", frags.len()),
+    };
+
+    let replacement = if is_standalone_line(input, start, end) {
+        out.push_str("-- ");
+        out.push_str(&token);
+        JinjaReplacement::StandaloneLine
+    } else if matches!(kind, JinjaTagKind::Comment) {
+        out.push_str("/* ");
+        out.push_str(&token);
+        out.push_str(" */");
+        JinjaReplacement::BlockComment
+    } else {
+        out.push_str(&token);
+        JinjaReplacement::Inline
+    };
+
+    frags.push(JinjaFragment {
+        token,
+        content: content.to_string(),
+        replacement,
+    });
+}
+
+fn is_standalone_line(input: &str, start: usize, end: usize) -> bool {
+    let before = input[..start]
+        .rsplit_once('\n')
+        .map(|(_, tail)| tail)
+        .unwrap_or(&input[..start]);
+    let after = input[end..]
+        .split_once('\n')
+        .map(|(head, _)| head)
+        .unwrap_or(&input[end..]);
+    before.trim().is_empty() && after.trim().is_empty()
+}
+
+fn find_tag_end(input: &str, mut idx: usize, close_a: u8, close_b: u8) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    while idx + 1 < bytes.len() {
+        let b = bytes[idx];
+
+        if escaped {
+            escaped = false;
+            idx += 1;
+            continue;
+        }
+
+        if in_single {
+            if b == b'\\' {
+                escaped = true;
+            } else if b == b'\'' {
+                in_single = false;
+            }
+            idx += 1;
+            continue;
+        }
+
+        if in_double {
+            if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_double = false;
+            }
+            idx += 1;
+            continue;
+        }
+
+        if b == b'\'' {
+            in_single = true;
+            idx += 1;
+            continue;
+        }
+        if b == b'"' {
+            in_double = true;
+            idx += 1;
+            continue;
+        }
+        if b == close_a && bytes[idx + 1] == close_b {
+            return Some(idx + 2);
+        }
+
+        idx += 1;
+    }
+
+    None
+}
+
+fn find_endraw_block(input: &str, mut idx: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    while idx + 1 < bytes.len() {
+        if bytes[idx] == b'{' && bytes[idx + 1] == b'%' {
+            let end = find_tag_end(input, idx + 2, b'%', b'}')?;
+            if block_tag_name(&input[idx..end]) == Some("endraw") {
+                return Some(end);
+            }
+            idx = end;
+        } else {
+            idx += 1;
+        }
+    }
+    None
+}
+
+fn block_tag_name(raw: &str) -> Option<&str> {
+    let inner = raw.strip_prefix("{%")?.strip_suffix("%}")?;
+    let inner = inner
+        .trim()
+        .strip_prefix('-')
+        .unwrap_or(inner.trim())
+        .trim_start();
+    let inner = inner.strip_suffix('-').unwrap_or(inner).trim_end();
+    inner.split_whitespace().next()
 }

--- a/src/format/sql/mod.rs
+++ b/src/format/sql/mod.rs
@@ -9,7 +9,7 @@ use sqlparser::ast::{
 };
 use sqlparser::dialect::{AnsiDialect, Dialect, GenericDialect};
 
-use crate::config::{DialectKind, FormatterConfig, KeywordCase};
+use crate::config::{DialectKind, FormatterConfig, KeywordCase, TemplatingMode};
 use crate::format::doc::Doc;
 use crate::format::printer::{format_doc, PrintConfig};
 use crate::parser::{parse_sql_with_options, DremioVersionClause, ParseOptions, ParsedStatement};
@@ -67,19 +67,19 @@ enum SelectLayout {
 }
 
 pub fn format_sql(input: &str, cfg: &FormatterConfig) -> Result<String> {
-    format_sql_impl(input, cfg, true)
-}
-
-fn format_sql_impl(input: &str, cfg: &FormatterConfig, allow_jinja_blocks: bool) -> Result<String> {
-    if allow_jinja_blocks && contains_jinja_markers(input) {
+    if cfg.templating == TemplatingMode::Passthrough && contains_jinja_markers(input) {
         return Ok(input.to_string());
     }
-    let comments = extract_comments(input, &cfg.dialect)?;
-    let (patched_input, jinja_exprs) = if allow_jinja_blocks {
+    format_sql_impl(input, cfg)
+}
+
+fn format_sql_impl(input: &str, cfg: &FormatterConfig) -> Result<String> {
+    let (patched_input, jinja_exprs) = if cfg.templating == TemplatingMode::Dbt {
         preserve_jinja_expressions(input)
     } else {
         (input.to_string(), Vec::new())
     };
+    let comments = extract_comments(&patched_input, &cfg.dialect)?;
     let (patched_input, literals) = preserve_string_literals(&patched_input);
     let stmts = parse_sql_with_options(
         &patched_input,
@@ -126,8 +126,8 @@ fn format_sql_impl(input: &str, cfg: &FormatterConfig, allow_jinja_blocks: bool)
     };
     let rendered = format_doc(&Doc::Concat(docs), &print_cfg);
     let restored = restore_string_literals(rendered, literals);
-    let restored = restore_jinja_expressions(restored, jinja_exprs);
-    reattach_comments(restored, comments, &cfg.dialect)
+    let restored = reattach_comments(restored, comments, &cfg.dialect)?;
+    Ok(restore_jinja_expressions(restored, jinja_exprs))
 }
 
 fn format_statement(
@@ -1436,7 +1436,7 @@ fn dialect_for_kind(kind: &DialectKind) -> Box<dyn Dialect> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{DialectKind, KeywordCase, SelectListStyle};
+    use crate::config::{DialectKind, KeywordCase, SelectListStyle, TemplatingMode};
     use std::fs;
     use std::path::{Path, PathBuf};
 
@@ -1453,6 +1453,36 @@ mod tests {
             .collect::<Vec<_>>();
         files.sort();
         files
+    }
+
+    fn fixture_paths(base: &str) -> Vec<PathBuf> {
+        let mut files = fs::read_dir(base)
+            .unwrap_or_else(|err| panic!("read {base}: {err}"))
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("sql"))
+            .collect::<Vec<_>>();
+        files.sort();
+        files
+    }
+
+    fn assert_fixture_matches(input_path: &Path, expected_path: &Path, cfg: &FormatterConfig) {
+        let input = fs::read_to_string(input_path).expect("read input fixture");
+        let expected = fs::read_to_string(expected_path).expect("read expected fixture");
+        let formatted = format_sql(&input, cfg)
+            .unwrap_or_else(|err| panic!("format failed for {:?}: {err}", input_path));
+        assert_eq!(
+            formatted.trim_end(),
+            expected.trim_end(),
+            "unexpected fixture output for {:?}",
+            input_path
+        );
+        let reformatted = format_sql(&formatted, cfg)
+            .unwrap_or_else(|err| panic!("reformat failed for {:?}: {err}", input_path));
+        assert_eq!(
+            reformatted, formatted,
+            "fixture output not idempotent for {:?}",
+            input_path
+        );
     }
 
     #[test]
@@ -2315,6 +2345,72 @@ WHERE order_date >= {{ start_date }}
 AND status <> 'CANCELLED'
 {% endif %}
 ;"
+        );
+    }
+
+    #[test]
+    fn formats_dbt_model_fixture() {
+        let cfg = FormatterConfig {
+            templating: TemplatingMode::Dbt,
+            ..Default::default()
+        };
+        assert_fixture_matches(
+            Path::new("fixtures/dbt/ansi/in/01_model.sql"),
+            Path::new("fixtures/dbt/ansi/expected/01_model.sql"),
+            &cfg,
+        );
+    }
+
+    #[test]
+    fn formats_dbt_dremio_incremental_fixture() {
+        let cfg = FormatterConfig {
+            dialect: DialectKind::Dremio,
+            templating: TemplatingMode::Dbt,
+            ..Default::default()
+        };
+        assert_fixture_matches(
+            Path::new("fixtures/dbt/dremio/in/01_incremental.sql"),
+            Path::new("fixtures/dbt/dremio/expected/01_incremental.sql"),
+            &cfg,
+        );
+    }
+
+    #[test]
+    fn formats_dbt_reference_syntax_idempotently() {
+        let cfg = FormatterConfig {
+            dialect: DialectKind::Dremio,
+            templating: TemplatingMode::Dbt,
+            ..Default::default()
+        };
+        for path in fixture_paths("fixtures/dbt/reference-syntax") {
+            let input = fs::read_to_string(&path).expect("read dbt reference fixture");
+            let formatted = format_sql(&input, &cfg)
+                .unwrap_or_else(|err| panic!("format failed for {:?}: {err}", path));
+            let reformatted = format_sql(&formatted, &cfg)
+                .unwrap_or_else(|err| panic!("reformat failed for {:?}: {err}", path));
+            assert_eq!(reformatted, formatted, "not idempotent for {:?}", path);
+        }
+    }
+
+    #[test]
+    fn preserves_dbt_tags_inside_strings_comments_and_raw_blocks() {
+        let cfg = FormatterConfig {
+            templating: TemplatingMode::Dbt,
+            ..Default::default()
+        };
+        let sql = "\
+{{ config(materialized=\"table\", post_hook=\"select 1; select 2\") }}
+SELECT '{{ var(\"literal\") }}' AS raw_template FROM {{ ref(\"orders\") }};
+-- depends_on: {{ ref(\"dim_orders\") }}
+{% raw %}{{ untouched }}{% endraw %}";
+        let out = format_str(sql, &cfg);
+        assert_eq!(
+            out.trim(),
+            "\
+{{ config(materialized=\"table\", post_hook=\"select 1; select 2\") }}
+SELECT '{{ var(\"literal\") }}' AS raw_template FROM {{ ref(\"orders\") }};
+-- depends_on: {{ ref(\"dim_orders\") }}
+{% raw %}{{ untouched }}{% endraw %}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 mod config;
 mod format;
 mod parser;
-use crate::config::{DialectKind, FormatterConfig, KeywordCase, SelectListStyle};
+use crate::config::{DialectKind, FormatterConfig, KeywordCase, SelectListStyle, TemplatingMode};
 use crate::format::sql::format_sql;
 use crate::parser::{parse_sql_with_options, ParseOptions, ParsedStatement};
 
@@ -51,6 +51,10 @@ struct Cli {
     /// Override dialect.
     #[arg(long, value_enum)]
     dialect: Option<DialectKind>,
+
+    /// Override templating mode.
+    #[arg(long, value_enum)]
+    templating: Option<TemplatingMode>,
 
     /// Override select list style.
     #[arg(long, value_enum)]
@@ -116,7 +120,8 @@ fn main() -> Result<()> {
             anyhow::bail!("no input provided; pass FILES or --stdin");
         }
 
-        let inputs = collect_input_files(&cli.files, &cli.include, &cli.exclude)?;
+        let inputs =
+            collect_input_files(&cli.files, &cli.include, &cli.exclude, config.templating)?;
 
         if inputs.is_empty() {
             anyhow::bail!("no input files found (looking for *.sql)");
@@ -173,6 +178,9 @@ fn apply_cli_overrides(config: &mut FormatterConfig, cli: &Cli) {
     if let Some(dialect) = cli.dialect {
         config.dialect = dialect;
     }
+    if let Some(templating) = cli.templating {
+        config.templating = templating;
+    }
     if let Some(select_list_style) = cli.select_list_style {
         config.select_list_style = select_list_style;
     }
@@ -221,10 +229,11 @@ fn collect_input_files(
     paths: &[PathBuf],
     includes: &[String],
     excludes: &[String],
+    templating: TemplatingMode,
 ) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     let mut seen = HashSet::new();
-    let matcher = build_matchers(includes, excludes)?;
+    let matcher = build_matchers(includes, excludes, templating)?;
     for path in paths {
         gather_paths(path, &mut files, &mut seen, &matcher)?;
     }
@@ -279,9 +288,25 @@ fn is_ignored_dir(name: &str) -> bool {
     matches!(name, ".git" | "target" | ".cargo")
 }
 
-fn build_matchers(includes: &[String], excludes: &[String]) -> Result<GlobMatchers> {
+fn build_matchers(
+    includes: &[String],
+    excludes: &[String],
+    templating: TemplatingMode,
+) -> Result<GlobMatchers> {
     let include_patterns = if includes.is_empty() {
-        vec![glob_to_regex("**/*.sql")?]
+        let patterns = match templating {
+            TemplatingMode::Passthrough => vec!["**/*.sql"],
+            TemplatingMode::Dbt => vec![
+                "**/*.sql",
+                "**/*.sql.j2",
+                "**/*.sql.jinja",
+                "**/*.sql.jinja2",
+            ],
+        };
+        patterns
+            .into_iter()
+            .map(glob_to_regex)
+            .collect::<Result<Vec<_>>>()?
     } else {
         includes
             .iter()
@@ -447,5 +472,26 @@ fn handle_input(
                 Ok(false)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dbt_templating_adds_template_extensions_to_default_includes() {
+        let matcher = build_matchers(&[], &[], TemplatingMode::Dbt).expect("matcher");
+        assert!(matcher.matches(Path::new("models/orders.sql")));
+        assert!(matcher.matches(Path::new("models/orders.sql.j2")));
+        assert!(matcher.matches(Path::new("models/orders.sql.jinja")));
+        assert!(matcher.matches(Path::new("models/orders.sql.jinja2")));
+    }
+
+    #[test]
+    fn passthrough_templating_keeps_sql_only_default_include() {
+        let matcher = build_matchers(&[], &[], TemplatingMode::Passthrough).expect("matcher");
+        assert!(matcher.matches(Path::new("models/orders.sql")));
+        assert!(!matcher.matches(Path::new("models/orders.sql.jinja")));
     }
 }


### PR DESCRIPTION
## Summary

Adds explicit dbt templating support as a mode layered on the existing SQL dialects. The default Jinja behavior remains passthrough, while `--templating dbt` protects dbt/Jinja tags, formats surrounding SQL, and restores tags exactly.

## Changes

- Adds `templating = "passthrough" | "dbt"` config and `--templating <passthrough|dbt>` CLI support.
- Adds dbt-aware Jinja preservation for expressions, blocks, comments, trim markers, raw blocks, and semicolons inside tags.
- Adds dbt default directory includes for `.sql`, `.sql.j2`, `.sql.jinja`, and `.sql.jinja2`.
- Adds dbt ANSI and Dremio fixtures plus reference syntax fixtures.
- Adds `docs/dbt-support-plan.md` as the trackable milestone/task plan and links it from docs.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (`99 passed`)
